### PR TITLE
use the unchanged description from the invoice

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -279,7 +279,7 @@ fn create_zap_note(
     // description of bolt11 invoice a JSON encoded zap request
     tags.push(Tag::Generic(
         TagKind::Custom("description".to_string()),
-        vec![zap_request_info.zap_request.as_json()],
+        vec![invoice.description],
     ));
 
     Ok(EventBuilder::new(nostr::Kind::Zap, "".to_string(), &tags).to_event(keys)?)


### PR DESCRIPTION
this fixes the display of zaps on Damus for me because Damus is checking the description hash.